### PR TITLE
Fixing AMASS loader and adding TFRecord loader

### DIFF
--- a/amass_tools/load_amass.py
+++ b/amass_tools/load_amass.py
@@ -84,16 +84,23 @@ def amass_example(bdata, framerate_drop=1, max_betas=10):
         gender_int = 0
     # Ensure that the number of betas is not greater than what is available
     num_betas = min(max_betas, bdata["betas"].shape[0])
+    # Keep only joint poses, discarding body orientation
+    # framerate_drop acts here, picking just part of the array
+    poses = bdata["poses"][0::framerate_drop, 3:72]
+    # Store the length (used for parsing)
+    num_poses = poses.shape[0]
     # Build feature dict
     feature = {
-        # Keep only joint poses, discarding body orientation
-        # framerate_drop acts here, picking just part of the array
-        "poses": _float_feature(
-            bdata["poses"][0::framerate_drop, 3:72].flatten()),
-        # Time interval between recordings, considering framerate drop
-        "dt": _float_feature([framerate_drop/bdata["mocap_framerate"]]),
+        # Flattened poses array
+        "poses": _float_feature(poses.flatten()),
+        # Number of pose frames
+        "num_poses": _int64_feature([num_poses]),
         # Shape components (betas), up to the maximum defined amount
         "betas": _float_feature(bdata["betas"][:num_betas]),
+        # Store the number of betas
+        "num_betas": _int64_feature([num_betas]),
+        # Time interval between recordings, considering framerate drop
+        "dt": _float_feature([framerate_drop/bdata["mocap_framerate"]]),
         # Gender encoded into integer
         "gender": _int64_feature([gender_int])
     }

--- a/amass_tools/load_tfrecord.py
+++ b/amass_tools/load_tfrecord.py
@@ -1,0 +1,61 @@
+"""
+load_amass.py
+
+Load the AMASS TFRecords created with "load_amass.py".
+This script is important for testing if data loaded into the TFRecord
+    file retains all necessary information for training.
+
+Author: Victor T. N.
+"""
+
+import os
+import time
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"  # Hide unnecessary TF messages
+import tensorflow as tf
+
+
+def parse_record(record):
+    feature_names = {
+        "poses": tf.io.FixedLenFeature([], tf.float32),
+        "dt": tf.io.FixedLenFeature([], tf.float32),
+        "betas": tf.io.FixedLenFeature([], tf.float32),
+        "gender": tf.io.FixedLenFeature([], tf.int64)
+    }
+    return tf.io.parse_single_example(record, feature_names)
+
+
+def decode_record(record):
+    poses = tf.reshape(record["poses"], [-1, 69])
+    dt = record["dt"]
+    betas = record["betas"]
+    if record["gender"] == 1:
+        gender = "female"
+    elif record["gender"] == -1:
+        gender = "male"
+    else:
+        gender = "neutral"
+    return poses, dt, betas, gender
+
+
+if __name__ == "__main__":
+    # Path where the TFRecords are located
+    tfr_path = "../../AMASS/tfrecords"
+    # Data splits (same as the filenames)
+    splits = ["train", "valid", "test"]
+    for split in splits:
+        # Full path to a single file
+        tfr_file_path = os.path.join(tfr_path, split + ".tfrecord")
+        # Load the TFRecord as a Dataset
+        dataset = tf.data.TFRecordDataset(tfr_file_path)
+        # Shuffle the dataset
+        dataset = dataset.shuffle(1000,
+                                  reshuffle_each_iteration=True)
+        for record in dataset:
+            # Parse and decode
+            poses, dt, betas, gender = decode_record(parse_record(record))
+            print(poses)
+            print(dt)
+            print(betas)
+            print(gender)
+            time.sleep(1)
+            break

--- a/amass_tools/load_tfrecord.py
+++ b/amass_tools/load_tfrecord.py
@@ -14,34 +14,45 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"  # Hide unnecessary TF messages
 import tensorflow as tf
 
 
-def parse_record(record):
+def parse_nums(record):
     feature_names = {
-        "poses": tf.io.FixedLenFeature([], tf.float32),
+        "num_poses": tf.io.FixedLenFeature([], tf.int64),
+        "num_betas": tf.io.FixedLenFeature([], tf.int64)
+    }
+    return tf.io.parse_single_example(record, feature_names)
+
+
+def parse_record(record, num_poses, num_betas):
+    feature_names = {
+        "poses": tf.io.FixedLenFeature([num_poses*69], tf.float32),
         "dt": tf.io.FixedLenFeature([], tf.float32),
-        "betas": tf.io.FixedLenFeature([], tf.float32),
+        "betas": tf.io.FixedLenFeature([num_betas], tf.float32),
         "gender": tf.io.FixedLenFeature([], tf.int64)
     }
     return tf.io.parse_single_example(record, feature_names)
 
 
 def decode_record(record):
-    poses = tf.reshape(record["poses"], [-1, 69])
-    dt = record["dt"]
-    betas = record["betas"]
-    if record["gender"] == 1:
+    p_nums = parse_nums(record)
+    p_record = parse_record(record, p_nums["num_poses"], p_nums["num_betas"])
+    poses = tf.reshape(p_record["poses"], [-1, 69])
+    betas = p_record["betas"]
+    dt = p_record["dt"]
+    if p_record["gender"] == 1:
         gender = "female"
-    elif record["gender"] == -1:
+    elif p_record["gender"] == -1:
         gender = "male"
     else:
         gender = "neutral"
-    return poses, dt, betas, gender
+    return poses, betas, dt, gender
 
 
 if __name__ == "__main__":
     # Path where the TFRecords are located
     tfr_path = "../../AMASS/tfrecords"
     # Data splits (same as the filenames)
-    splits = ["train", "valid", "test"]
+    # splits = ["train", "valid", "test"]
+    splits = ["test"]
     for split in splits:
         # Full path to a single file
         tfr_file_path = os.path.join(tfr_path, split + ".tfrecord")
@@ -52,10 +63,10 @@ if __name__ == "__main__":
                                   reshuffle_each_iteration=True)
         for record in dataset:
             # Parse and decode
-            poses, dt, betas, gender = decode_record(parse_record(record))
+            poses, betas, dt, gender = decode_record(record)
             print(poses)
             print(dt)
             print(betas)
             print(gender)
+            print("\n\n")
             time.sleep(1)
-            break

--- a/amass_tools/view_amass.py
+++ b/amass_tools/view_amass.py
@@ -67,7 +67,9 @@ if __name__ == "__main__":
 
     # Path to the AMASS motion npz file
     # npz_bdata_path = "../../AMASS/datasets/KIT/3/912_3_01_poses.npz"
-    npz_bdata_path = "../../AMASS/datasets/Eyes_Japan_Dataset/hamada/accident-01-dodge-hamada_poses.npz"
+    npz_bdata_path = "../../AMASS/datasets/KIT/314/run04_poses.npz"
+    # npz_bdata_path = "../../AMASS/datasets/KIT/314/parkour02_poses.npz"
+    # npz_bdata_path = "../../AMASS/datasets/Eyes_Japan_Dataset/hamada/accident-01-dodge-hamada_poses.npz"
     # npz_bdata_path = "../../AMASS/datasets/BMLhandball/S03_Expert/Trial_upper_left_140_poses.npz"
     # npz_bdata_path = "../../AMASS/datasets/TCD_handMocap/ExperimentDatabase/OK_A_poses.npz"
 


### PR DESCRIPTION
AMASS loader (from npz to TFRecord) now works serially (one process for each split: train, test and valid), solving file corruption.

Also adds a TFRecord loader, mainly used to check integrity of the TFRecord files and demonstrate how to load them.