### PR TITLE
Multiprocessing for AMASS loading

### DIFF
--- a/amass_tools/amass_to_tfrecord.py
+++ b/amass_tools/amass_to_tfrecord.py
@@ -1,5 +1,5 @@
 """
-load_amass.py
+amass_to_tfrecord.py
 
 Load the downloaded AMASS database (.npz files) into TFRecords.
 This is the preferred binary file for TensorFlow, and has performance
@@ -14,7 +14,8 @@ import concurrent.futures
 import glob
 import numpy as np
 import os
-from tqdm import trange
+import sys
+import tqdm
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"  # Hide unnecessary TF messages
 import tensorflow as tf
 
@@ -107,53 +108,49 @@ def amass_example(bdata, framerate_drop=1, max_betas=10):
     return tf.train.Example(features=tf.train.Features(feature=feature))
 
 
-def write_tfrecord(amass_path, tfr_path, split, sub_datasets, position):
-    """Parses a full split from AMASS and writes to a TFRecord file.
-    Each output file is handled by a separate process.
+def write_tfrecord(input_path, output_path, description, position):
+    """Parses a full sub-dataset from AMASS and writes to a TFRecord file.
+    Each sub-dataset is handled by a separate process.
+    Files can be joined when loading with tf.data.TFRecordDataset.
 
     Args:
-        amass_path (string): path to the directory that contains all the
-                             AMASS sub-datasets.
-        tfr_path (string): path to the directory to store the TFRecords.
-        split (string): name of the dataset split (train, valid or test).
-        sub_datasets (string): list with the names of the sub-datasets.
-        position (int): where to locate the tqdm progress bar.
+        input_path (string): path to the sub-dataset, containing .npz files.
+        output_path (string): full path to the output file, with extension.
+        description (string): description for the tqdm progress bar.
+        position (int): position for the tqdm progress bar.
     """
-    # Path to output file (.tfrecord)
-    output_path = os.path.join(tfr_path, split + ".tfrecord")
+    # Path to input files (.npz) with wildcards
+    npz_path = os.path.join(input_path, "*/*.npz")
+    # Expand with glob
+    npz_list = glob.glob(npz_path)
+    # Create a record writer
     with tf.io.TFRecordWriter(output_path) as writer:
-        # Iterate over all sub-datasets
-        for sub_dataset in sub_datasets:
-            # Create a description string
-            description = sub_dataset + " (" + split + ")"
-            # Path to input files (.npz), with wildcards
-            input_path = os.path.join(amass_path, sub_dataset, "*/*.npz")
-            # Expand the input paths with glob
-            input_list = glob.glob(input_path)
-            # Iterate over all input files of this sub-dataset
-            for i in trange(len(input_list), desc=description,
-                            position=position, dynamic_ncols=True,
-                            mininterval=1.0, leave=False):
-                # Try to load specified file
-                try:
-                    bdata = np.load(input_list[i])
-                except Exception as ex:
-                    print(ex + "\nError loading " + input_list[i])
+        # Iterate over all input files
+        for i in tqdm.trange(len(npz_list), desc=description,
+                             position=position, dynamic_ncols=True,
+                             mininterval=0.5):
+            # Try to load specified file
+            try:
+                bdata = np.load(npz_list[i])
+            except IOError:
+                print("Error loading " + npz_list[i])
+            except ValueError:
+                print("allow_pickle=True required to load " + npz_list[i])
+            else:
+                if "poses" not in list(bdata.keys()):
+                    # Skip a non-valid file
+                    continue
                 else:
-                    if "poses" not in list(bdata.keys()):
-                        # Skip a non-valid file
-                        continue
-                    else:
-                        for fr_drop in [1, 2, 4, 10]:
-                            # Create the Example
-                            tf_example = amass_example(bdata, fr_drop)
-                            # Write to TFRecord file
-                            writer.write(tf_example.SerializeToString())
+                    for fr_drop in [1, 2, 4, 10]:
+                        # Create the Example
+                        tf_example = amass_example(bdata, fr_drop)
+                        # Write to TFRecord file
+                        writer.write(tf_example.SerializeToString())
 
 
 if __name__ == "__main__":
     # Path to the datasets
-    amass_path = "../../AMASS/datasets"
+    amass_home = "../../AMASS/datasets"
     # Split the sub-datasets into training, validation and testing
     # This names must match the subfolders of "amass_path"
     # Inexistent directories will be skipped
@@ -165,13 +162,38 @@ if __name__ == "__main__":
         "test": ["SSM_synced", "Transitions_mocap"]
     }
     # Path to save the TFRecords files
-    tfr_path = "../../AMASS/tfrecords"
-    # Create an executor
+    tfr_home = "../../AMASS/tfrecords"
+    # Iterate over all splits
+    for split in amass_splits.keys():
+        # Path for the corresponding subdirectory
+        tfr_subdir = os.path.join(tfr_home, split)
+        # Create the subdirectory, if it doesn't exist
+        try:
+            os.mkdir(tfr_subdir)
+        except FileExistsError:
+            print(f"Directory {tfr_subdir} already exists and will be used.")
+        except FileNotFoundError:
+            print(f"Directory {tfr_subdir} is invalid.")
+            sys.exit()
+        else:
+            print(f"Creating new directory {tfr_subdir}.")
+    # Create a multiprocessing executor
     with concurrent.futures.ProcessPoolExecutor() as executor:
-        # Iterate over the splits
+        # This position variable controls the position of progress bars
         position = 0
+        # Iterate over all splits
         for split in amass_splits.keys():
-            sub_datasets = amass_splits[split]
-            executor.submit(write_tfrecord, amass_path, tfr_path,
-                            split, sub_datasets, position)
-            position += 1
+            # Iterate over the sub-datasets
+            for sub_ds in amass_splits[split]:
+                # Create the input path
+                input_path = os.path.join(amass_home, sub_ds)
+                # Create the output path
+                output_path = os.path.join(tfr_home, split,
+                                           sub_ds + ".tfrecord")
+                # Create a description string
+                description = sub_ds + " (" + split + ")"
+                # Start the process
+                executor.submit(write_tfrecord, input_path,
+                                output_path, description, position)
+                # Increment position counter
+                position += 1

--- a/amass_tools/amass_to_tfrecord.py
+++ b/amass_tools/amass_to_tfrecord.py
@@ -17,7 +17,7 @@ import os
 import sys
 import tqdm
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"  # Hide unnecessary TF messages
-import tensorflow as tf
+import tensorflow as tf  # noqa: E402
 
 
 def _bytes_feature(value):

--- a/amass_tools/load_tfrecord.py
+++ b/amass_tools/load_tfrecord.py
@@ -68,25 +68,27 @@ if __name__ == "__main__":
     # Path where the TFRecords are located
     tfr_home = "../../AMASS/tfrecords"
     # Data splits (same as the filenames)
-    # splits = ["train", "valid", "test"]
-    splits = ["test"]
+    splits = ["train", "valid", "test"]
     for split in splits:
+        # Display information
+        print(f"Loading \"{split}\" split\n")
         # Full path to the datasets of a specific split, with wildcards
         tfr_paths = os.path.join(tfr_home, split, "*.tfrecord")
         # Expand with glob
         tfr_list = glob.glob(tfr_paths)
         # Load the TFRecords as a Dataset
-        dataset = tf.data.TFRecordDataset(tfr_paths,
+        dataset = tf.data.TFRecordDataset(tfr_list,
                                           num_parallel_reads=os.cpu_count())
         # Shuffle the dataset
         dataset = dataset.shuffle(1000,
                                   reshuffle_each_iteration=True)
-        for record in dataset:
-            # Parse and decode
-            poses, betas, dt, gender = decode_record(parse_record(record))
-            print(poses)
-            print(dt)
-            print(betas)
-            print(gender)
-            print("\n\n")
-            time.sleep(1)
+        # Take a record as example
+        record = next(iter(dataset))
+        # Parse and decode
+        poses, betas, dt, gender = decode_record(parse_record(record))
+        # Show data
+        print(f"Poses: {poses}\n")
+        print(f"dt: {dt}\n")
+        print(f"betas: {betas}\n")
+        print(f"gender: {gender}\n\n")
+        time.sleep(1)

--- a/amass_tools/load_tfrecord.py
+++ b/amass_tools/load_tfrecord.py
@@ -1,20 +1,29 @@
 """
-load_amass.py
+load_tfrecord.py
 
-Load the AMASS TFRecords created with "load_amass.py".
+Load the AMASS TFRecords created with "amass_to_tfrecord.py".
 This script is important for testing if data loaded into the TFRecord
     file retains all necessary information for training.
 
 Author: Victor T. N.
 """
 
+import glob
 import os
 import time
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"  # Hide unnecessary TF messages
-import tensorflow as tf
+import tensorflow as tf  # noqa: E402
 
 
 def parse_record(record):
+    """Parse a single record from the dataset.
+
+    Args:
+        record (raw dataset record): a single record from the dataset.
+
+    Returns:
+        (parsed record): a single parsed record from the dataset.
+    """
     num_names = {
         "num_poses": tf.io.FixedLenFeature([], tf.int64),
         "num_betas": tf.io.FixedLenFeature([], tf.int64)
@@ -30,6 +39,19 @@ def parse_record(record):
 
 
 def decode_record(parsed_record):
+    """Decode a previously parsed record.
+
+    Args:
+        parsed_record (raw dataset record): a single record from the dataset,
+                                            previously parsed by the
+                                            "parse_record" function.
+
+    Returns:
+        poses (tensor): N x 69 tensor with the sequence of poses.
+        betas (tensor): 1D tensor with all shape primitives.
+        dt (tensor): float tensor with the time step for this sequence.
+        gender (string): gender of the subject.
+    """
     poses = tf.reshape(parsed_record["poses"], [-1, 69])
     betas = parsed_record["betas"]
     dt = parsed_record["dt"]
@@ -44,15 +66,18 @@ def decode_record(parsed_record):
 
 if __name__ == "__main__":
     # Path where the TFRecords are located
-    tfr_path = "../../AMASS/tfrecords"
+    tfr_home = "../../AMASS/tfrecords"
     # Data splits (same as the filenames)
     # splits = ["train", "valid", "test"]
     splits = ["test"]
     for split in splits:
-        # Full path to a single file
-        tfr_file_path = os.path.join(tfr_path, split + ".tfrecord")
-        # Load the TFRecord as a Dataset
-        dataset = tf.data.TFRecordDataset(tfr_file_path)
+        # Full path to the datasets of a specific split, with wildcards
+        tfr_paths = os.path.join(tfr_home, split, "*.tfrecord")
+        # Expand with glob
+        tfr_list = glob.glob(tfr_paths)
+        # Load the TFRecords as a Dataset
+        dataset = tf.data.TFRecordDataset(tfr_paths,
+                                          num_parallel_reads=os.cpu_count())
         # Shuffle the dataset
         dataset = dataset.shuffle(1000,
                                   reshuffle_each_iteration=True)

--- a/amass_tools/view_amass.py
+++ b/amass_tools/view_amass.py
@@ -16,8 +16,8 @@ import numpy as np
 import trimesh
 import os
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"  # Hide unnecessary TF messages
-from star.tf.star import STAR
-import tensorflow as tf
+import tensorflow as tf  # noqa: E402
+from star.tf.star import STAR  # noqa: E402
 
 
 FACE_COLORS = (0, 255, 65, 255)  # Color for mesh faces

--- a/amass_tools/view_amass.py
+++ b/amass_tools/view_amass.py
@@ -64,17 +64,15 @@ def update_scene(scene):
 
 
 if __name__ == "__main__":
+    # Home for all AMASS datasets
+    amass_home = "../../AMASS/datasets"
+    # Subpath for the npz_file
+    npz_path = "Eyes_Japan_Dataset/hamada/accident-01-dodge-hamada_poses.npz"
+    # Joint paths
+    full_path = os.path.join(amass_home, npz_path)
 
-    # Path to the AMASS motion npz file
-    # npz_bdata_path = "../../AMASS/datasets/KIT/3/912_3_01_poses.npz"
-    npz_bdata_path = "../../AMASS/datasets/KIT/314/run04_poses.npz"
-    # npz_bdata_path = "../../AMASS/datasets/KIT/314/parkour02_poses.npz"
-    # npz_bdata_path = "../../AMASS/datasets/Eyes_Japan_Dataset/hamada/accident-01-dodge-hamada_poses.npz"
-    # npz_bdata_path = "../../AMASS/datasets/BMLhandball/S03_Expert/Trial_upper_left_140_poses.npz"
-    # npz_bdata_path = "../../AMASS/datasets/TCD_handMocap/ExperimentDatabase/OK_A_poses.npz"
-
-    # Load the compressed numpy file
-    bdata = np.load(npz_bdata_path)
+    # Load the compressed NumPy file
+    bdata = np.load(full_path)
 
     # Print info
     print('Data keys available:%s' % list(bdata.keys()))


### PR DESCRIPTION
Multiprocessing now works for loading the AMASS npz files into TFRecords. This is managed by creating a file for each sub-dataset.

When loading the TFRecords with tf.data, it is possible to load all the files of a specific split (train, valid or test), enabling even parallel calls.